### PR TITLE
Workaround for keyboard mashers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
     "jsdelivr",
     "KEYBIND",
     "Keybinds",
+    "keypresses",
     "loglevel",
     "lzutf8",
     "mathematicalbasedefenders",

--- a/client/src/public/ts/index.ts
+++ b/client/src/public/ts/index.ts
@@ -59,6 +59,7 @@ const variables: { [key: string]: any } = {
   // below is for beautifulScoreCounter
   scoreOnLastUpdate: 0,
   playing: false,
+  serverReportsPlaying: false,
   settings: {
     multiplicationSign: "dot",
     beautifulScore: false

--- a/client/src/public/ts/input.ts
+++ b/client/src/public/ts/input.ts
@@ -53,31 +53,34 @@ const ELEMENTS_TO_NOT_SEND_WEBSOCKET_MESSAGE = [
 // events
 function initializeKeypressEventListener() {
   window.addEventListener("keydown", (event) => {
-    let sendWebsocketMessage = true;
+    let sendWebSocketMessage = true;
     // other client-side events start
     if (event.code === "Tab") {
       event.preventDefault();
       $("#status-tray-container").toggle(0);
-      sendWebsocketMessage = false;
+      sendWebSocketMessage = false;
     }
     if (ARROW_KEYS.indexOf(event.code) > -1) {
       event.preventDefault();
       navigateFocus(event.code);
-      sendWebsocketMessage = false;
+      sendWebSocketMessage = false;
     }
     if (!WEBSOCKET_MESSAGE_SEND_KEYS.includes(event.code)) {
-      sendWebsocketMessage = false;
+      sendWebSocketMessage = false;
     }
     const focusedElement = document.activeElement;
     if (focusedElement) {
       const focusedElementJQuery = $(focusedElement)[0];
       const focusedElementID = "#" + focusedElementJQuery.id;
       if (ELEMENTS_TO_NOT_SEND_WEBSOCKET_MESSAGE.includes(focusedElementID)) {
-        sendWebsocketMessage = false;
+        sendWebSocketMessage = false;
       }
     }
+    if (!variables.serverReportsPlaying) {
+      sendWebSocketMessage = false;
+    }
     // see if a websocket message should be sent
-    if (!sendWebsocketMessage) {
+    if (!sendWebSocketMessage) {
       return;
     }
     // main client-side events start

--- a/client/src/public/ts/input.ts
+++ b/client/src/public/ts/input.ts
@@ -79,6 +79,9 @@ function initializeKeypressEventListener() {
     if (!variables.serverReportsPlaying) {
       sendWebSocketMessage = false;
     }
+    if (variables.currentGameClientSide.currentInput.length >= 12) {
+      sendWebSocketMessage = false;
+    }
     // see if a websocket message should be sent
     if (!sendWebSocketMessage) {
       return;

--- a/client/src/public/ts/input.ts
+++ b/client/src/public/ts/input.ts
@@ -64,26 +64,30 @@ function initializeKeypressEventListener() {
       message: "keypress",
       keypress: event.code
     });
-    // also take care of client-side.
-    const numberRowKeyIndex = NUMBER_ROW_KEYS.indexOf(event.code);
-    const numberPadKeyIndex = NUMBER_PAD_KEYS.indexOf(event.code);
-    const removeDigitKeyIndex = REMOVE_DIGIT_KEYS.indexOf(event.code);
-    const subtractionSignKeyIndex = SUBTRACTION_SIGN_KEYS.indexOf(event.code);
-    if (numberRowKeyIndex > -1) {
-      variables.currentGameClientSide.currentInput +=
-        numberRowKeyIndex.toString();
-    } else if (numberPadKeyIndex > -1) {
-      variables.currentGameClientSide.currentInput +=
-        numberPadKeyIndex.toString();
-    } else if (subtractionSignKeyIndex > -1) {
-      variables.currentGameClientSide.currentInput += "-";
-    } else if (removeDigitKeyIndex > -1) {
-      const newLength = variables.currentGameClientSide.currentInput.length - 1;
-      variables.currentGameClientSide.currentInput =
-        variables.currentGameClientSide.currentInput.substring(0, newLength);
-    }
+    handleClientSideEvents(event);
     // main client-side events end
   });
+}
+
+function handleClientSideEvents(event: KeyboardEvent) {
+  // also take care of client-side.
+  const numberRowKeyIndex = NUMBER_ROW_KEYS.indexOf(event.code);
+  const numberPadKeyIndex = NUMBER_PAD_KEYS.indexOf(event.code);
+  const removeDigitKeyIndex = REMOVE_DIGIT_KEYS.indexOf(event.code);
+  const subtractionSignKeyIndex = SUBTRACTION_SIGN_KEYS.indexOf(event.code);
+  if (numberRowKeyIndex > -1) {
+    variables.currentGameClientSide.currentInput +=
+      numberRowKeyIndex.toString();
+  } else if (numberPadKeyIndex > -1) {
+    variables.currentGameClientSide.currentInput +=
+      numberPadKeyIndex.toString();
+  } else if (subtractionSignKeyIndex > -1) {
+    variables.currentGameClientSide.currentInput += "-";
+  } else if (removeDigitKeyIndex > -1) {
+    const newLength = variables.currentGameClientSide.currentInput.length - 1;
+    variables.currentGameClientSide.currentInput =
+      variables.currentGameClientSide.currentInput.substring(0, newLength);
+  }
 }
 
 function checkIfShouldSendWebSocketMessage(event: KeyboardEvent) {

--- a/client/src/public/ts/input.ts
+++ b/client/src/public/ts/input.ts
@@ -28,18 +28,56 @@ const NUMBER_PAD_KEYS = [
 const REMOVE_DIGIT_KEYS = ["NumpadAdd", "Backspace"];
 const SUBTRACTION_SIGN_KEYS = ["Minus", "NumpadSubtract"];
 const ARROW_KEYS = ["ArrowLeft", "ArrowUp", "ArrowDown", "ArrowRight"];
+const ABORT_KEYS = ["Escape"];
+const SEND_KEYS = ["Space", "Enter"];
+// send websocket message keys
+const WEBSOCKET_MESSAGE_SEND_KEYS = NUMBER_ROW_KEYS.concat(
+  NUMBER_PAD_KEYS,
+  REMOVE_DIGIT_KEYS,
+  SUBTRACTION_SIGN_KEYS,
+  ABORT_KEYS,
+  SEND_KEYS
+);
+// ignore send websocket elements
+const ELEMENTS_TO_NOT_SEND_WEBSOCKET_MESSAGE = [
+  "#settings-screen__content--online__username",
+  "#settings-screen__content--online__password",
+  "#custom-singleplayer-game__combo-time",
+  "#custom-singleplayer-game__enemy-spawn-time",
+  "#custom-singleplayer-game__enemy-spawn-chance",
+  "#custom-singleplayer-game__forced-enemy-spawn-time",
+  "#custom-singleplayer-game__enemy-speed-coefficient",
+  "#custom-singleplayer-game__starting-base-health"
+];
+
 // events
 function initializeKeypressEventListener() {
   window.addEventListener("keydown", (event) => {
+    let sendWebsocketMessage = true;
     // other client-side events start
     if (event.code === "Tab") {
       event.preventDefault();
       $("#status-tray-container").toggle(0);
-      return;
+      sendWebsocketMessage = false;
     }
     if (ARROW_KEYS.indexOf(event.code) > -1) {
       event.preventDefault();
       navigateFocus(event.code);
+      sendWebsocketMessage = false;
+    }
+    if (!WEBSOCKET_MESSAGE_SEND_KEYS.includes(event.code)) {
+      sendWebsocketMessage = false;
+    }
+    const focusedElement = document.activeElement;
+    if (focusedElement) {
+      const focusedElementJQuery = $(focusedElement)[0];
+      const focusedElementID = "#" + focusedElementJQuery.id;
+      if (ELEMENTS_TO_NOT_SEND_WEBSOCKET_MESSAGE.includes(focusedElementID)) {
+        sendWebsocketMessage = false;
+      }
+    }
+    // see if a websocket message should be sent
+    if (!sendWebsocketMessage) {
       return;
     }
     // main client-side events start

--- a/client/src/public/ts/input.ts
+++ b/client/src/public/ts/input.ts
@@ -79,7 +79,20 @@ function initializeKeypressEventListener() {
     if (!variables.serverReportsPlaying) {
       sendWebSocketMessage = false;
     }
-    if (variables.currentGameClientSide.currentInput.length >= 12) {
+    if (
+      variables.currentGameClientSide.currentInput.length >= 8 &&
+      !REMOVE_DIGIT_KEYS.includes(event.code) &&
+      !ABORT_KEYS.includes(event.code) &&
+      !SEND_KEYS.includes(event.code)
+    ) {
+      sendWebSocketMessage = false;
+    }
+    if (
+      variables.currentGameClientSide.currentInput.length <= 0 &&
+      (REMOVE_DIGIT_KEYS.includes(event.code) ||
+        SEND_KEYS.includes(event.code)) &&
+      !ABORT_KEYS.includes(event.code)
+    ) {
       sendWebSocketMessage = false;
     }
     // see if a websocket message should be sent

--- a/client/src/public/ts/input.ts
+++ b/client/src/public/ts/input.ts
@@ -53,48 +53,8 @@ const ELEMENTS_TO_NOT_SEND_WEBSOCKET_MESSAGE = [
 // events
 function initializeKeypressEventListener() {
   window.addEventListener("keydown", (event) => {
-    let sendWebSocketMessage = true;
     // other client-side events start
-    if (event.code === "Tab") {
-      event.preventDefault();
-      $("#status-tray-container").toggle(0);
-      sendWebSocketMessage = false;
-    }
-    if (ARROW_KEYS.indexOf(event.code) > -1) {
-      event.preventDefault();
-      navigateFocus(event.code);
-      sendWebSocketMessage = false;
-    }
-    if (!WEBSOCKET_MESSAGE_SEND_KEYS.includes(event.code)) {
-      sendWebSocketMessage = false;
-    }
-    const focusedElement = document.activeElement;
-    if (focusedElement) {
-      const focusedElementJQuery = $(focusedElement)[0];
-      const focusedElementID = "#" + focusedElementJQuery.id;
-      if (ELEMENTS_TO_NOT_SEND_WEBSOCKET_MESSAGE.includes(focusedElementID)) {
-        sendWebSocketMessage = false;
-      }
-    }
-    if (!variables.serverReportsPlaying) {
-      sendWebSocketMessage = false;
-    }
-    if (
-      variables.currentGameClientSide.currentInput.length >= 8 &&
-      !REMOVE_DIGIT_KEYS.includes(event.code) &&
-      !ABORT_KEYS.includes(event.code) &&
-      !SEND_KEYS.includes(event.code)
-    ) {
-      sendWebSocketMessage = false;
-    }
-    if (
-      variables.currentGameClientSide.currentInput.length <= 0 &&
-      (REMOVE_DIGIT_KEYS.includes(event.code) ||
-        SEND_KEYS.includes(event.code)) &&
-      !ABORT_KEYS.includes(event.code)
-    ) {
-      sendWebSocketMessage = false;
-    }
+    const sendWebSocketMessage = checkIfShouldSendWebSocketMessage(event);
     // see if a websocket message should be sent
     if (!sendWebSocketMessage) {
       return;
@@ -124,5 +84,55 @@ function initializeKeypressEventListener() {
     }
     // main client-side events end
   });
+}
+
+function checkIfShouldSendWebSocketMessage(event: KeyboardEvent) {
+  // overrides: set to false
+  let sendWebSocketMessage = true;
+  if (event.code === "Tab") {
+    event.preventDefault();
+    $("#status-tray-container").toggle(0);
+    sendWebSocketMessage = false;
+  }
+  if (ARROW_KEYS.indexOf(event.code) > -1) {
+    event.preventDefault();
+    navigateFocus(event.code);
+    sendWebSocketMessage = false;
+  }
+  if (!WEBSOCKET_MESSAGE_SEND_KEYS.includes(event.code)) {
+    sendWebSocketMessage = false;
+  }
+  const focusedElement = document.activeElement;
+  if (focusedElement) {
+    const focusedElementJQuery = $(focusedElement)[0];
+    const focusedElementID = "#" + focusedElementJQuery.id;
+    if (ELEMENTS_TO_NOT_SEND_WEBSOCKET_MESSAGE.includes(focusedElementID)) {
+      sendWebSocketMessage = false;
+    }
+  }
+  if (!variables.serverReportsPlaying) {
+    sendWebSocketMessage = false;
+  }
+  if (
+    variables.currentGameClientSide.currentInput.length >= 8 &&
+    !REMOVE_DIGIT_KEYS.includes(event.code) &&
+    !ABORT_KEYS.includes(event.code) &&
+    !SEND_KEYS.includes(event.code)
+  ) {
+    sendWebSocketMessage = false;
+  }
+  if (
+    variables.currentGameClientSide.currentInput.length <= 0 &&
+    (REMOVE_DIGIT_KEYS.includes(event.code) ||
+      SEND_KEYS.includes(event.code)) &&
+    !ABORT_KEYS.includes(event.code)
+  ) {
+    sendWebSocketMessage = false;
+  }
+  // overrides: set to true
+  if (variables.serverReportsInMultiplayer && ABORT_KEYS.includes(event.code)) {
+    sendWebSocketMessage = true;
+  }
+  return sendWebSocketMessage;
 }
 export { initializeKeypressEventListener };

--- a/client/src/public/ts/socket.ts
+++ b/client/src/public/ts/socket.ts
@@ -84,6 +84,7 @@ socket.addEventListener("message", (event: any) => {
     }
     case "updateSocketMetadata": {
       variables.serverReportsPlaying = message.data.playing;
+      variables.serverReportsInMultiplayer = message.data.inMultiplayerRoom;
       break;
     }
   }

--- a/client/src/public/ts/socket.ts
+++ b/client/src/public/ts/socket.ts
@@ -82,6 +82,10 @@ socket.addEventListener("message", (event: any) => {
       updateSystemStatusTrayText(message.data);
       break;
     }
+    case "updateSocketMetadata": {
+      variables.serverReportsPlaying = message.data.playing;
+      break;
+    }
   }
 });
 function sendSocketMessage(message: { [key: string]: string }) {

--- a/cypress/e2e/keypresses.cy.js
+++ b/cypress/e2e/keypresses.cy.js
@@ -5,7 +5,7 @@ describe("keypresses", () => {
     cy.get("#main-menu-screen-button--multiplayer").click();
     cy.get("#multiplayer-menu-screen-button--default").click();
     cy.wait(1000);
-    cy.type(`{esc}`);
+    cy.get("#chat-message").type(`{esc}`);
     cy.get("#main-menu-screen-button--singleplayer").should("be.visible");
   });
 });

--- a/cypress/e2e/keypresses.cy.js
+++ b/cypress/e2e/keypresses.cy.js
@@ -1,0 +1,11 @@
+describe("keypresses", () => {
+  it("should allow users to exit multiplayer room intermission through abort key", () => {
+    cy.visit("http://localhost:3000");
+    cy.get("#popup-notification--1__close-button").click();
+    cy.get("#main-menu-screen-button--multiplayer").click();
+    cy.get("#multiplayer-menu-screen-button--default").click();
+    cy.wait(1000);
+    cy.type(`{esc}`);
+    cy.get("#main-menu-screen-button--singleplayer").should("be.visible");
+  });
+});

--- a/server/src/core/utilities.ts
+++ b/server/src/core/utilities.ts
@@ -351,7 +351,7 @@ function createGlobalLeaderboardsMessage(data: GameData, rank: number) {
  * @returns How many messages the GameSocket would have sent as if 1000ms has passed,
  * or -1 if socket doesn't have the `accumulatedMessages` property.
  */
-function getWebsocketMessageSpeed(socket: universal.GameSocket, time: number) {
+function getWebSocketMessageSpeed(socket: universal.GameSocket, time: number) {
   if (socket.accumulatedMessages) {
     return (1000 / Math.max(15, time)) * socket.accumulatedMessages;
   }
@@ -361,14 +361,16 @@ function getWebsocketMessageSpeed(socket: universal.GameSocket, time: number) {
 /**
  *
  */
-function checkWebsocketMessageSpeeds(
+function checkWebSocketMessageSpeeds(
   sockets: Array<universal.GameSocket>,
   time: number
 ) {
   const socketsToForceDelete = [];
   for (const socket of sockets) {
     if (socket.accumulatedMessages) {
-      const amount = getWebsocketMessageSpeed(socket, time);
+      const amount = getWebSocketMessageSpeed(socket, time);
+      // FIXME: remove this
+      console.log(`${amount} wsmps`);
       if (amount > MESSAGES_PER_SECOND_LIMIT) {
         log.warn(
           `Disconnecting socket ${socket.connectionID} for sending too many messages at once. (${amount} per second > ${MESSAGES_PER_SECOND_LIMIT} per second)`
@@ -412,6 +414,6 @@ export {
   bulkUpdateSocketUserInformation,
   sleep,
   createGlobalLeaderboardsMessage,
-  getWebsocketMessageSpeed,
-  checkWebsocketMessageSpeeds
+  getWebSocketMessageSpeed,
+  checkWebSocketMessageSpeeds
 };

--- a/server/src/core/utilities.ts
+++ b/server/src/core/utilities.ts
@@ -369,10 +369,6 @@ function checkWebSocketMessageSpeeds(
   for (const socket of sockets) {
     if (typeof socket.accumulatedMessages === "number") {
       const amount = getWebSocketMessageSpeed(socket, time);
-      // FIXME: remove this
-      if (amount > 0) {
-        console.log(`${amount} ws msg./s`);
-      }
       if (amount > MESSAGES_PER_SECOND_LIMIT) {
         log.warn(
           `Disconnecting socket ${socket.connectionID} for sending too many messages at once. (${amount} per second > ${MESSAGES_PER_SECOND_LIMIT} per second)`

--- a/server/src/core/utilities.ts
+++ b/server/src/core/utilities.ts
@@ -14,6 +14,8 @@ const RANK_ORDER = [
   ["Donator", "isDonator"]
 ];
 
+const MESSAGES_PER_SECOND_TIME_PERIOD = 200;
+let timePeriodPassedForMessageSpeed = 0;
 const MESSAGES_PER_SECOND_LIMIT = 500;
 
 const SINGLEPLAYER_CUSTOM_SETTINGS_BOUNDARIES: { [key: string]: any } = {
@@ -365,6 +367,11 @@ function checkWebSocketMessageSpeeds(
   sockets: Array<universal.GameSocket>,
   time: number
 ) {
+  timePeriodPassedForMessageSpeed += time;
+  // here incase Nms is too low (e.g. 1 msg. in 1ms => 1000 msg./s => disconnect)
+  if (timePeriodPassedForMessageSpeed < MESSAGES_PER_SECOND_TIME_PERIOD) {
+    return;
+  }
   const socketsToForceDelete = [];
   for (const socket of sockets) {
     if (typeof socket.accumulatedMessages === "number") {
@@ -390,6 +397,8 @@ function checkWebSocketMessageSpeeds(
   for (const socket of socketsToForceDelete) {
     universal.forceDeleteAndCloseSocket(socket);
   }
+  // modulo instead of subtract because it doesn't get check multiple times.
+  timePeriodPassedForMessageSpeed %= MESSAGES_PER_SECOND_TIME_PERIOD;
 }
 
 // Taken from https://stackoverflow.com/a/39914235

--- a/server/src/core/utilities.ts
+++ b/server/src/core/utilities.ts
@@ -367,10 +367,10 @@ function checkWebSocketMessageSpeeds(
 ) {
   const socketsToForceDelete = [];
   for (const socket of sockets) {
-    if (socket.accumulatedMessages) {
+    if (typeof socket.accumulatedMessages === "number") {
       const amount = getWebSocketMessageSpeed(socket, time);
       // FIXME: remove this
-      console.log(`${amount} wsmps`);
+      console.log(`${amount} ws msg./s`);
       if (amount > MESSAGES_PER_SECOND_LIMIT) {
         log.warn(
           `Disconnecting socket ${socket.connectionID} for sending too many messages at once. (${amount} per second > ${MESSAGES_PER_SECOND_LIMIT} per second)`

--- a/server/src/core/utilities.ts
+++ b/server/src/core/utilities.ts
@@ -370,7 +370,7 @@ function checkWebSocketMessageSpeeds(
     if (typeof socket.accumulatedMessages === "number") {
       const amount = getWebSocketMessageSpeed(socket, time);
       // FIXME: remove this
-      if (amount > -1) {
+      if (amount > 0) {
         console.log(`${amount} ws msg./s`);
       }
       if (amount > MESSAGES_PER_SECOND_LIMIT) {

--- a/server/src/core/utilities.ts
+++ b/server/src/core/utilities.ts
@@ -14,7 +14,7 @@ const RANK_ORDER = [
   ["Donator", "isDonator"]
 ];
 
-const MESSAGES_PER_SECOND_LIMIT = 1500;
+const MESSAGES_PER_SECOND_LIMIT = 500;
 
 const SINGLEPLAYER_CUSTOM_SETTINGS_BOUNDARIES: { [key: string]: any } = {
   baseHealth: {

--- a/server/src/core/utilities.ts
+++ b/server/src/core/utilities.ts
@@ -14,7 +14,7 @@ const RANK_ORDER = [
   ["Donator", "isDonator"]
 ];
 
-const MESSAGES_PER_SECOND_LIMIT = 1600;
+const MESSAGES_PER_SECOND_LIMIT = 1500;
 
 const SINGLEPLAYER_CUSTOM_SETTINGS_BOUNDARIES: { [key: string]: any } = {
   baseHealth: {

--- a/server/src/core/utilities.ts
+++ b/server/src/core/utilities.ts
@@ -352,7 +352,7 @@ function createGlobalLeaderboardsMessage(data: GameData, rank: number) {
  * or -1 if socket doesn't have the `accumulatedMessages` property.
  */
 function getWebSocketMessageSpeed(socket: universal.GameSocket, time: number) {
-  if (socket.accumulatedMessages) {
+  if (typeof socket.accumulatedMessages === "number") {
     return (1000 / Math.max(15, time)) * socket.accumulatedMessages;
   }
   return -1;
@@ -370,7 +370,9 @@ function checkWebSocketMessageSpeeds(
     if (typeof socket.accumulatedMessages === "number") {
       const amount = getWebSocketMessageSpeed(socket, time);
       // FIXME: remove this
-      console.log(`${amount} ws msg./s`);
+      if (amount > -1) {
+        console.log(`${amount} ws msg./s`);
+      }
       if (amount > MESSAGES_PER_SECOND_LIMIT) {
         log.warn(
           `Disconnecting socket ${socket.connectionID} for sending too many messages at once. (${amount} per second > ${MESSAGES_PER_SECOND_LIMIT} per second)`

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -317,7 +317,7 @@ function update(deltaTime: number) {
   }
 
   // CHECK FOR BAD SOCKETS
-  utilities.checkWebsocketMessageSpeeds(universal.sockets, deltaTime);
+  utilities.checkWebSocketMessageSpeeds(universal.sockets, deltaTime);
   // DATA IS SENT HERE. <---
   const systemStatus = updateSystemStatus(deltaTime);
   synchronizeGameDataWithSockets(deltaTime, systemStatus || {});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -92,6 +92,28 @@ const UPDATE_INTERVAL: number = 1000 / DESIRED_SERVER_UPDATES_PER_SECOND;
 const SYNCHRONIZATION_INTERVAL: number =
   1000 / DESIRED_SYNCHRONIZATIONS_PER_SECOND;
 
+// https://github.com/uNetworking/uWebSockets.js/issues/335#issuecomment-643500581
+// https://github.com/uNetworking/uWebSockets.js/issues/335#issuecomment-834141711
+const WebSocketRateLimit = (limit: number, interval: number) => {
+  let now = 0;
+  // const last = Symbol() as unknown as string;
+  // const count = Symbol() as unknown as string;
+  setInterval(() => ++now, interval);
+  return (webSocket: universal.GameSocket) => {
+    if (!webSocket.rateLimiting) {
+      return;
+    }
+    if (webSocket.rateLimiting.last != now) {
+      webSocket.rateLimiting.last = now;
+      webSocket.rateLimiting.count = 1;
+    } else {
+      return ++webSocket.rateLimiting.count > limit;
+    }
+  };
+};
+
+const websocketRateLimit = WebSocketRateLimit(500, 1000);
+
 let initialized = false;
 
 let currentTime: number = Date.now();
@@ -123,6 +145,10 @@ uWS
       socket.connectionID = utilities.generateConnectionID(16);
       socket.ownerGuestName = `Guest ${utilities.generateGuestID(8)}`;
       socket.accumulatedMessages = 0;
+      socket.rateLimiting = {
+        last: 1,
+        count: 0
+      };
       universal.sockets.push(socket);
       log.info(`There are now ${universal.sockets.length} sockets connected.`);
       socket.subscribe("game");
@@ -148,6 +174,19 @@ uWS
       message: WebSocketMessage,
       isBinary: boolean
     ) => {
+      if (websocketRateLimit(socket)) {
+        socket?.send(
+          JSON.stringify({
+            message: "createToastNotification",
+            // TODO: Refactor this
+            text: `You're going too fast! You have been immediately disconnected.`,
+            borderColor: "#ff0000"
+          })
+        );
+        log.warn(`Rate-limited and killing socket ${socket.connectionID}.`);
+        universal.forceDeleteAndCloseSocket(socket);
+        return;
+      }
       const buffer = Buffer.from(message);
       const incompleteParsedMessage = JSON.parse(buffer.toString());
       if (!incompleteParsedMessage) {

--- a/server/src/universal.ts
+++ b/server/src/universal.ts
@@ -27,6 +27,10 @@ type GameSocket = WebSocket<UserData> & {
   loggedIn?: boolean;
   playerRank?: PlayerRank;
   accumulatedMessages?: number;
+  rateLimiting?: {
+    last: number;
+    count: number;
+  };
 };
 
 let sockets: Array<GameSocket> = [];

--- a/server/src/universal.ts
+++ b/server/src/universal.ts
@@ -7,7 +7,11 @@ import {
 } from "./game/Room";
 import { GameData, SingleplayerGameData } from "./game/GameData";
 import _, { update } from "lodash";
-import { minifySelfGameData, findRoomWithConnectionID } from "./core/utilities";
+import {
+  minifySelfGameData,
+  findRoomWithConnectionID,
+  checkIfPropertyWithValueExists
+} from "./core/utilities";
 import { log } from "./core/log";
 
 // 0.4.10
@@ -141,6 +145,17 @@ function checkIfSocketIsPlaying(id: string) {
   return getGameDataFromConnectionID(id) != null;
 }
 
+function checkIfSocketIsInMultiplayerRoom(id: string) {
+  const room = findRoomWithConnectionID(id);
+  if (!room) {
+    return false;
+  }
+  if (room.mode !== "defaultMultiplayer") {
+    return false;
+  }
+  return true;
+}
+
 /**
  * Synchronizes the game data of the server from the server-side to the client-side.
  * @param {GameSocket} socket The socket to sync data with.
@@ -161,12 +176,15 @@ function synchronizeMetadataWithSocket(
   );
   // socket metadata
   if (socket.connectionID) {
-    const socketIsPlaying = checkIfSocketIsPlaying(socket.connectionID);
+    const id = socket.connectionID;
+    const socketIsPlaying = checkIfSocketIsPlaying(id);
+    const socketIsInMPRoom = checkIfSocketIsInMultiplayerRoom(id);
     socket.send(
       JSON.stringify({
         message: "updateSocketMetadata",
         data: {
-          playing: socketIsPlaying
+          playing: socketIsPlaying,
+          inMultiplayerRoom: socketIsInMPRoom
         }
       })
     );


### PR DESCRIPTION
This pull request attempts to fix issues with anticheat code in this repository flagging legitimate players who are going to fast. (e.g. mashing their keyboard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a configuration option for keypress handling in the development environment.
	- Introduced a new property to track server game state, improving responsiveness.
	- Enhanced keyboard event handling for WebSocket message sending.
	- Added handling for new socket message types to update game state.
	- Implemented a new Cypress test suite for evaluating keypress functionality in multiplayer.
	- Introduced a rate-limiting mechanism for WebSocket message sending.
	- Added functions to check socket game and multiplayer status.

- **Bug Fixes**
	- Improved message handling logic to enhance performance and reliability.

- **Tests**
	- Added end-to-end tests for keypress events during gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->