### PR TITLE
Reduce Input "Flickering"

### DIFF
--- a/client/src/public/ts/game.ts
+++ b/client/src/public/ts/game.ts
@@ -21,7 +21,6 @@ const OPTIMAL_SCREEN_RATIO: number =
 // TODO: Change `any` to something else.
 function renderGameData(data: { [key: string]: any }) {
   // pre actions go here.
-  const timestampOfFunctionCall = Date.now();
   if (data.aborted) {
     variables.playing = false;
   }
@@ -146,18 +145,6 @@ function renderGameData(data: { [key: string]: any }) {
   }
 
   // text
-  if (
-    data.timestampOfSynchronization > timestampOfFunctionCall ||
-    variables.watchingReplay
-  ) {
-    stageItems.textSprites.inputText.text = data.currentInput.replaceAll(
-      "-",
-      "−"
-    );
-  } else {
-    stageItems.textSprites.inputText.text =
-      variables.currentGameClientSide.currentInput.replaceAll("-", "−");
-  }
 
   stageItems.textSprites.enemiesText.text = `Enemy Kills: ${data.enemiesKilled.toLocaleString(
     "en-US"
@@ -206,12 +193,14 @@ function renderGameData(data: { [key: string]: any }) {
   variables.currentGameClientSide.timeSinceLastEnemyKill =
     data.clocks.comboReset.currentTime;
   variables.currentGameClientSide.baseHealth = data.baseHealth;
-  variables.currentGameClientSide.currentInput = data.currentInput;
   variables.currentGameClientSide.level = data.level;
   variables.currentGameClientSide.enemySpeedCoefficient =
     data.enemySpeedCoefficient;
   variables.currentGameClientSide.beautifulScoreDisplayGoal = data.score;
   variables.currentGameClientSide.shownScore = data.score;
+  variables.currentGameClientSide.timestampOfSynchronization =
+    data.timestampOfSynchronization;
+  variables.currentGameClientSide.synchronizedInput = data.currentInput;
 
   // level display for singleplayer
   if (

--- a/client/src/public/ts/game.ts
+++ b/client/src/public/ts/game.ts
@@ -21,6 +21,7 @@ const OPTIMAL_SCREEN_RATIO: number =
 // TODO: Change `any` to something else.
 function renderGameData(data: { [key: string]: any }) {
   // pre actions go here.
+  const timestampOfFunctionCall = Date.now();
   if (data.aborted) {
     variables.playing = false;
   }
@@ -145,10 +146,19 @@ function renderGameData(data: { [key: string]: any }) {
   }
 
   // text
-  stageItems.textSprites.inputText.text = data.currentInput.replaceAll(
-    "-",
-    "−"
-  );
+  if (
+    data.timestampOfSynchronization > timestampOfFunctionCall ||
+    variables.watchingReplay
+  ) {
+    stageItems.textSprites.inputText.text = data.currentInput.replaceAll(
+      "-",
+      "−"
+    );
+  } else {
+    stageItems.textSprites.inputText.text =
+      variables.currentGameClientSide.currentInput.replaceAll("-", "−");
+  }
+
   stageItems.textSprites.enemiesText.text = `Enemy Kills: ${data.enemiesKilled.toLocaleString(
     "en-US"
   )} ≈ ${((data.enemiesKilled / data.elapsedTime) * 1000).toFixed(3)}/s`;

--- a/client/src/public/ts/index.ts
+++ b/client/src/public/ts/index.ts
@@ -146,7 +146,9 @@ const variables: { [key: string]: any } = {
     shownScore: 0,
     beautifulScoreDisplayGoal: 0,
     beautifulScoreDisplayProgress: 0,
-    beautifulScoreDisplayPrevious: 0
+    beautifulScoreDisplayPrevious: 0,
+    timestampOfSynchronization: 0,
+    synchronizedInput: ""
   },
   navigation: {
     currentScreen: "openingScreen",

--- a/client/src/public/ts/rendering.ts
+++ b/client/src/public/ts/rendering.ts
@@ -144,6 +144,8 @@ function resetClientSideVariables() {
   variables.currentGameClientSide.beautifulScoreDisplayGoal = 0;
   variables.currentGameClientSide.beautifulScoreDisplayProgress = 0;
   variables.currentGameClientSide.beautifulScoreDisplayPrevious = 0;
+  variables.currentGameClientSide.currentInput = "";
+  variables.currentGameClientSide.synchronizedInput = "";
 }
 
 /**

--- a/client/src/public/ts/rendering.ts
+++ b/client/src/public/ts/rendering.ts
@@ -89,14 +89,6 @@ function render(elapsedMilliseconds: number) {
       stageItems.textSprites.inputText.text =
         variables.currentGameClientSide.currentInput.replaceAll("-", "−");
     }
-
-    console.log(
-      variables.currentGameClientSide.timestampOfSynchronization,
-      timestampOfFunctionCall,
-      variables.currentGameClientSide.timestampOfSynchronization >
-        timestampOfFunctionCall,
-      variables.currentGameClientSide.currentInput
-    );
   }
 
   /**

--- a/client/src/public/ts/rendering.ts
+++ b/client/src/public/ts/rendering.ts
@@ -11,6 +11,8 @@ import { formatNumber, millisecondsToTime } from "./utilities";
  * This should be overwritten by server data.
  */
 function render(elapsedMilliseconds: number) {
+  const timestampOfFunctionCall = Date.now();
+
   /**
    * Update replay data as well
    */
@@ -76,8 +78,25 @@ function render(elapsedMilliseconds: number) {
     // combo text fading
     stageItems.textSprites.comboText.alpha = comboTextAlpha;
     // input
-    stageItems.textSprites.inputText.text =
-      variables.currentGameClientSide.currentInput.replaceAll("-", "−");
+    if (
+      variables.currentGameClientSide.timestampOfSynchronization >
+        timestampOfFunctionCall ||
+      variables.watchingReplay
+    ) {
+      stageItems.textSprites.inputText.text =
+        variables.currentGameClientSide.synchronizedInput;
+    } else {
+      stageItems.textSprites.inputText.text =
+        variables.currentGameClientSide.currentInput.replaceAll("-", "−");
+    }
+
+    console.log(
+      variables.currentGameClientSide.timestampOfSynchronization,
+      timestampOfFunctionCall,
+      variables.currentGameClientSide.timestampOfSynchronization >
+        timestampOfFunctionCall,
+      variables.currentGameClientSide.currentInput
+    );
   }
 
   /**

--- a/client/src/public/ts/socket.ts
+++ b/client/src/public/ts/socket.ts
@@ -298,7 +298,7 @@ socket.addEventListener("message", (event: any) => {
           message.data.toClear[character]
         ) {
           variables.currentGameClientSide.currentInput =
-            variables.currentGameClientSide.currentInput.substr(1);
+            variables.currentGameClientSide.currentInput.substring(1);
         } else {
           break;
         }

--- a/client/src/public/ts/socket.ts
+++ b/client/src/public/ts/socket.ts
@@ -303,6 +303,7 @@ socket.addEventListener("message", (event: any) => {
           break;
         }
       }
+      break;
     }
   }
 });

--- a/client/src/public/ts/socket.ts
+++ b/client/src/public/ts/socket.ts
@@ -285,6 +285,24 @@ socket.addEventListener("message", (event: any) => {
       );
 
       $(selector).append(chatMessage);
+      break;
+    }
+    case "clearInput": {
+      for (
+        let character = 0;
+        character < message.data.toClear.length;
+        character++
+      ) {
+        if (
+          variables.currentGameClientSide.currentInput[0] ===
+          message.data.toClear[character]
+        ) {
+          variables.currentGameClientSide.currentInput =
+            variables.currentGameClientSide.currentInput.substr(1);
+        } else {
+          break;
+        }
+      }
     }
   }
 });

--- a/server/src/core/input.ts
+++ b/server/src/core/input.ts
@@ -275,6 +275,21 @@ function processInputInformation(
           }
         }
       }
+      if (enemyKilled) {
+        const ownerSocket = universal.getSocketFromConnectionID(
+          gameDataToProcess.ownerConnectionID
+        );
+        if (ownerSocket) {
+          ownerSocket.send(
+            JSON.stringify({
+              message: "clearInput",
+              data: {
+                toClear: gameDataToProcess.currentInput.toString()
+              }
+            })
+          );
+        }
+      }
       // reset input
       if (enemyKilled) {
         gameDataToProcess.currentInput = "";

--- a/server/src/game/GameData.ts
+++ b/server/src/game/GameData.ts
@@ -98,6 +98,12 @@ class GameData {
   receivedEnemiesStock!: number;
   /**  (Multiplayer) The number of enemies in stock to be spawned from `GameData`.*/
   receivedEnemiesToSpawn!: number;
+  // ... (0.5.0-rc.2)
+  /**
+   * The timestamp of the last action before sending to socket.
+   * Only used for client and server synchronization, never used for internal server calculations.
+   */
+  timestampOfSynchronization!: number;
 
   constructor(owner: universal.GameSocket, mode: GameMode) {
     this.mode = mode;
@@ -169,6 +175,7 @@ class GameData {
       this.enemySpeedCoefficient = 1; // +0.05 every level
       this.enemySpawnThreshold = 0.1;
     }
+    this.timestampOfSynchronization = Date.now();
   }
 }
 class SingleplayerGameData extends GameData {

--- a/server/src/universal.ts
+++ b/server/src/universal.ts
@@ -228,6 +228,7 @@ function synchronizeGameDataWithSocket(socket: GameSocket) {
   );
   const clonedSocketGameData = _.cloneDeep(socketGameData);
   if (clonedSocketGameData) {
+    clonedSocketGameData.timestampOfSynchronization = Date.now();
     // remove some game data
     minifySelfGameData(clonedSocketGameData);
     // add some game data (extra information)


### PR DESCRIPTION
When playing from faraway from the server's location, the numbers seem to flicker due to how the data is synchronzied between the client and the server.

This pull requests aims to fix it by changing how the current input number handling works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added synchronization of input state between client and server, including a timestamp to ensure accurate display of input.
	- Introduced a mechanism to clear specific characters from the input field in real-time when certain in-game events occur.

- **Improvements**
	- The input display now prefers showing synchronized input from the server when available, improving consistency during gameplay.
	- Enhanced reset functionality to clear both local and synchronized input states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->