### PR TITLE
Expanding enemy target value ranges.

### DIFF
--- a/server/src/game/Enemy.ts
+++ b/server/src/game/Enemy.ts
@@ -1,6 +1,6 @@
 import _ from "lodash";
 import { log } from "../core/log";
-import { GameData, MultiplayerGameData } from "./GameData";
+import { GameData, GameMode, MultiplayerGameData } from "./GameData";
 import { USE_TESTING_VALUES } from "../universal";
 import { TESTING_VALUES } from "../testing-configuration/values";
 import { findRoomWithConnectionID } from "../core/utilities";
@@ -11,6 +11,8 @@ const POSSIBLE_FACTORS = [2, 3, 4, 5, 6, 8, 9, 10, 11];
 const DEFAULT_SPEED = 1 / 60;
 
 interface EnemyAttributes {
+  low?: number;
+  high?: number;
   attack?: number;
   health?: number;
   color?: number;
@@ -160,22 +162,28 @@ function removeEnemyWithIDInGameData(id: string, gameData: GameData) {
 }
 
 function createNewEnemy(id: string, attributes?: EnemyAttributes) {
-  // TODO: Change this algorithm (line below)
-  let generatedValue: number = Math.round(Math.random() * 200 - 100);
+  const DEFAULT_LOW = -100;
+  const DEFAULT_HIGH = 100;
+  const low = attributes?.low ?? DEFAULT_LOW;
+  const high = attributes?.high ?? DEFAULT_HIGH;
+  const generatedValue = Math.random() * (high - low + 1) + low;
+
+  let targetValue = Math.floor(generatedValue);
+
   /**
    * If testing mode is used, then ignore generated value and use set value
    * So the app can behave deterministically.
    */
   if (USE_TESTING_VALUES) {
     if (TESTING_VALUES && typeof TESTING_VALUES.forcedEnemyValue === "number") {
-      generatedValue = TESTING_VALUES.forcedEnemyValue;
+      targetValue = TESTING_VALUES.forcedEnemyValue;
     } else {
       console.warn("Testing value faulty, using original value instead.");
     }
   }
   let enemy: Enemy = new Enemy(
-    generatedValue,
-    createProblem(generatedValue),
+    targetValue,
+    createProblem(targetValue),
     Math.random(),
     1,
     attributes?.speed || 0.1,
@@ -260,4 +268,56 @@ function getFactorsOf(number: number): Array<number> {
   return factors;
 }
 
-export { createNewEnemy, createNewReceivedEnemy, Enemy, EnemyAttributes };
+function getEnemyAttributesBasedOnGameData(data: GameData) {
+  switch (data.mode) {
+    case GameMode.DefaultMultiplayer:
+    case GameMode.CustomMultiplayer: {
+      return getMultiplayerEnemyAttributesBasedOnGameData(data);
+    }
+    case GameMode.EasySingleplayer:
+    case GameMode.StandardSingleplayer:
+    case GameMode.InsaneSingleplayer:
+    case GameMode.CustomSingleplayer: {
+      return getSingleplayerEnemyAttributesBasedOnGameData(data);
+    }
+    default: {
+      return getSingleplayerEnemyAttributesBasedOnGameData(data);
+    }
+  }
+}
+
+function getSingleplayerEnemyAttributesBasedOnGameData(data: GameData) {
+  const EXPANSION_PER_LEVEL = 10;
+  const RANGE_START = 100;
+  // enemy generated value will never go above or below +/-999
+  const EXTREME = 999;
+  const rangeExpand = (data.level - 1) * EXPANSION_PER_LEVEL;
+  const attributes: EnemyAttributes = {
+    low: Math.max(-(RANGE_START + rangeExpand), -EXTREME),
+    high: Math.min(RANGE_START + rangeExpand, EXTREME)
+  };
+  return attributes;
+}
+
+function getMultiplayerEnemyAttributesBasedOnGameData(data: GameData) {
+  const MILLISECONDS_PER_RANGE_EXPAND = 1250;
+  const RANGE_START = 100;
+  // enemy generated value will never go above or below +/-999
+  const EXTREME = 999;
+  const rangeExpand = Math.floor(
+    data.elapsedTime / MILLISECONDS_PER_RANGE_EXPAND
+  );
+  const attributes: EnemyAttributes = {
+    low: Math.max(-(RANGE_START + rangeExpand), -EXTREME),
+    high: Math.min(RANGE_START + rangeExpand, EXTREME)
+  };
+  return attributes;
+}
+
+export {
+  createNewEnemy,
+  createNewReceivedEnemy,
+  Enemy,
+  EnemyAttributes,
+  getEnemyAttributesBasedOnGameData
+};

--- a/server/src/game/Enemy.ts
+++ b/server/src/game/Enemy.ts
@@ -269,6 +269,12 @@ function getFactorsOf(number: number): Array<number> {
 }
 
 function getEnemyAttributesBasedOnGameData(data: GameData) {
+  if (!data) {
+    // if no `GameData` is supplied, give an
+    // attribute-less object
+    return {};
+  }
+
   switch (data.mode) {
     case GameMode.DefaultMultiplayer:
     case GameMode.CustomMultiplayer: {

--- a/server/src/game/Enemy.ts
+++ b/server/src/game/Enemy.ts
@@ -287,7 +287,7 @@ function getEnemyAttributesBasedOnGameData(data: GameData) {
 }
 
 function getSingleplayerEnemyAttributesBasedOnGameData(data: GameData) {
-  const EXPANSION_PER_LEVEL = 10;
+  const EXPANSION_PER_LEVEL = data.mode === GameMode.EasySingleplayer ? 0 : 10;
   const RANGE_START = 100;
   // enemy generated value will never go above or below +/-999
   const EXTREME = 999;

--- a/server/src/game/MultiplayerRoom.ts
+++ b/server/src/game/MultiplayerRoom.ts
@@ -301,11 +301,12 @@ class MultiplayerRoom extends Room {
       checkPlayerMultiplayerRoomClocks(data);
 
       // attributes
-      const attributes = getEnemyAttributesBasedOnGameData(data);
+      const enemyAttributes = getEnemyAttributesBasedOnGameData(data);
 
       // forced enemy (when zero)
       if (data.enemies.length === 0) {
-        const enemy = createNewEnemy(`F${data.enemiesSpawned}`, attributes);
+        const enemyNumber = data.enemiesSpawned;
+        const enemy = createNewEnemy(`F${enemyNumber}`, enemyAttributes);
         this.gameActionRecord.addEnemySpawnAction(enemy, data);
         data.enemies.push(_.clone(enemy));
         data.enemiesSpawned++;

--- a/server/src/game/MultiplayerRoom.ts
+++ b/server/src/game/MultiplayerRoom.ts
@@ -12,7 +12,7 @@ import {
   checkPlayerMultiplayerRoomClocks
 } from "./actions/clocks";
 import { changeClientSideText } from "./actions/send-html";
-import { createNewEnemy } from "./Enemy";
+import { createNewEnemy, getEnemyAttributesBasedOnGameData } from "./Enemy";
 import {
   ClockInterface,
   GameMode,
@@ -300,9 +300,12 @@ class MultiplayerRoom extends Room {
       // clocks
       checkPlayerMultiplayerRoomClocks(data);
 
+      // attributes
+      const attributes = getEnemyAttributesBasedOnGameData(data);
+
       // forced enemy (when zero)
       if (data.enemies.length === 0) {
-        const enemy = createNewEnemy(`F${data.enemiesSpawned}`);
+        const enemy = createNewEnemy(`F${data.enemiesSpawned}`, attributes);
         this.gameActionRecord.addEnemySpawnAction(enemy, data);
         data.enemies.push(_.clone(enemy));
         data.enemiesSpawned++;

--- a/server/src/game/MultiplayerRoom.ts
+++ b/server/src/game/MultiplayerRoom.ts
@@ -323,10 +323,11 @@ class MultiplayerRoom extends Room {
       if (data.receivedEnemiesToSpawn > 0) {
         data.receivedEnemiesToSpawn--;
         data.enemiesSpawned++;
-        const attributes = {
-          speed:
-            GAME_DATA_CONSTANTS.ENEMY_BASE_SPEED * data.enemySpeedCoefficient
-        };
+
+        const attributes = getEnemyAttributesBasedOnGameData(data);
+        attributes.speed =
+          GAME_DATA_CONSTANTS.ENEMY_BASE_SPEED * data.enemySpeedCoefficient;
+
         const receivedEnemy = enemy.createNewReceivedEnemy(
           `R${data.enemiesSpawned}`,
           attributes

--- a/server/src/game/actions/clocks.ts
+++ b/server/src/game/actions/clocks.ts
@@ -1,7 +1,11 @@
 // package files
 import _ from "lodash";
 // other files
-import { Enemy, createNewEnemy } from "../Enemy";
+import {
+  Enemy,
+  createNewEnemy,
+  getEnemyAttributesBasedOnGameData
+} from "../Enemy";
 import { GameData } from "../GameData";
 import { Room } from "../Room";
 import { findRoomWithConnectionID } from "../../core/utilities";
@@ -28,7 +32,14 @@ function checkPlayerMultiplayerRoomClocks(data: GameData) {
  */
 function checkGlobalMultiplayerRoomClocks(room: MultiplayerRoom) {
   room.globalEnemyToAdd = null;
-  const enemyToAdd: Enemy = createNewEnemy(`G${room.updateNumber}`);
+
+  // Hopefully `room.gameData[0]` always contain a `GameData` instance,
+  // since `elapsedTime` is generally synchronized across every `GameData`
+  // instance anyway.
+  // TODO: Make this more robust.
+  const enemyAttributes = getEnemyAttributesBasedOnGameData(room.gameData[0]);
+
+  const enemyToAdd = createNewEnemy(`G${room.updateNumber}`, enemyAttributes);
   const forcedEnemySpawnClock = room.globalClock.forcedEnemySpawn;
   const enemySpawnClock = room.globalClock.enemySpawn;
   let forcedSpawned = false;

--- a/server/src/game/actions/clocks.ts
+++ b/server/src/game/actions/clocks.ts
@@ -33,7 +33,8 @@ function checkGlobalMultiplayerRoomClocks(room: MultiplayerRoom) {
   // since `elapsedTime` is generally synchronized across every `GameData`
   // instance anyway.
   // TODO: Make this more robust.
-  const enemyAttributes = getEnemyAttributesBasedOnGameData(room.gameData[0]);
+  const referenceGameData = room.gameData?.[0] || null;
+  const enemyAttributes = getEnemyAttributesBasedOnGameData(referenceGameData);
 
   const enemyToAdd = createNewEnemy(`G${room.updateNumber}`, enemyAttributes);
   const forcedEnemySpawnClock = room.globalClock.forcedEnemySpawn;

--- a/server/src/game/actions/clocks.ts
+++ b/server/src/game/actions/clocks.ts
@@ -1,11 +1,7 @@
 // package files
 import _ from "lodash";
 // other files
-import {
-  Enemy,
-  createNewEnemy,
-  getEnemyAttributesBasedOnGameData
-} from "../Enemy";
+import { createNewEnemy, getEnemyAttributesBasedOnGameData } from "../Enemy";
 import { GameData } from "../GameData";
 import { Room } from "../Room";
 import { findRoomWithConnectionID } from "../../core/utilities";
@@ -68,7 +64,8 @@ function checkGlobalMultiplayerRoomClocks(room: MultiplayerRoom) {
  * @param {Room} room The room of the data.
  */
 function checkEnemyTimeClocks(data: GameData, room: Room) {
-  const enemyToAdd: Enemy = createNewEnemy(`G${room.updateNumber}`);
+  const enemyAttributes = getEnemyAttributesBasedOnGameData(data);
+  const enemyToAdd = createNewEnemy(`G${room.updateNumber}`, enemyAttributes);
   const forcedEnemySpawnClock = data.clocks.forcedEnemySpawn;
   const enemySpawnClock = data.clocks.enemySpawn;
   let forcedSpawned = false;

--- a/server/src/game/actions/update.ts
+++ b/server/src/game/actions/update.ts
@@ -3,7 +3,7 @@ import * as _ from "lodash";
 // other files
 import { checkSingleplayerRoomClocks } from "./clocks";
 import { GameData } from "../GameData";
-import { createNewEnemy } from "../Enemy";
+import { createNewEnemy, getEnemyAttributesBasedOnGameData } from "../Enemy";
 import { log } from "../../core/log";
 import { findRoomWithConnectionID } from "../../core/utilities";
 import { SingleplayerRoom } from "../SingleplayerRoom";
@@ -80,7 +80,8 @@ function checkForceSpawnEnemyCondition(data: GameData, room: SingleplayerRoom) {
     return false;
   }
 
-  const enemy = createNewEnemy(`F${room.updateNumber}`);
+  const enemyAttributes = getEnemyAttributesBasedOnGameData(data);
+  const enemy = createNewEnemy(`F${room.updateNumber}`, enemyAttributes);
   room.gameActionRecord.addEnemySpawnAction(enemy, data);
 
   data.enemies.push(_.clone(enemy));


### PR DESCRIPTION
Allow enemies to "expand" their target values over the range `[-100, 100]` up to `[-999, 999]` based on game progress.

- Easy Singleplayer: Values do not expand (they stay at `[-100, 100]`)
- Standard/Insane (not here yet)/Custom Singleplayer: Expand by `10` per 1 game level.
- Default/Custom Multiplayer: Expand by `1` for everyone per 1250ms elapsed time.

Note that `[-999, 999]` is the hard limit (as of this pull request), if the values go over the range, it will be brought back to the range.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Improvements

* **Dynamic Enemy Difficulty Scaling**: Enemies now intelligently scale their challenge based on game progression. In singleplayer modes, difficulty increases with player level. In multiplayer, enemies become progressively tougher as match duration increases, creating more adaptive gameplay experiences.
* **Enhanced Testing Mode**: Improved override behavior for forced enemy values during testing and quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->